### PR TITLE
Updare libsignal-service revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "34b9e43" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "34b9e43" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "3424b55" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "3424b55" }
 
 actix-threadpool = "0.3"
 aes = "0.7"


### PR DESCRIPTION
In libsignal-service, the dependency to libsignal-client got pinned:
https://github.com/whisperfish/libsignal-service-rs/commit/3424b55d3e64890c48659ee7616942baa64b995b

Crayfish should use this.

I don't know if this breaks something, but I want to highlight this change. It relates to #1.