### PR TITLE
Add the gpl licence

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,18 @@
+    crayfish - a rust backend for the signal-server
+    
+    Copyright (C) 2021  Jonatan Zeidler
+    Copyright (C) 2021  blackoverflow
+    Copyright (C) 2022  Aaron Kimmig
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
We are still missing a licence for crayfish. Crayfish has also commits from @jonnius and @Blackoverflow. So you both need to give your agreement to add the licence. Jut do it by  thumbs-up.

closes #6 