### PR TITLE
Remove cargo linker config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,0 @@
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
Our cargo config hard-codes gcc as linker. The linker should be configured via an env var instead.