### PR TITLE
Some compile fixes (see TODOs!)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
  "sha-1 0.9.8",
  "sha2 0.9.9",
  "tokio",
- "uuid 0.7.4",
+ "uuid",
  "version_check",
  "warp",
 ]
@@ -1055,7 +1055,7 @@ dependencies = [
  "sha2 0.9.9",
  "subtle",
  "thiserror",
- "uuid 0.8.2",
+ "uuid",
  "x25519-dalek",
 ]
 
@@ -1088,7 +1088,7 @@ dependencies = [
  "sha2 0.10.2",
  "thiserror",
  "url",
- "uuid 0.8.2",
+ "uuid",
  "zkgroup",
 ]
 
@@ -2524,15 +2524,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde-big-array = { version="0.3.2", features = ["const-generics"] }
 serde_str = "0.1.0"
 serde_yaml = "0.8"
 tokio = { version= "1", features = ["full"] }
-uuid = { version = "0.7.4", features = [ "serde" ] }
+uuid = { version = "0.8", features = [ "serde" ] }
 warp = "0.3"
 
 hmac = "0.11.0"

--- a/src/signal_service/sealedsender.rs
+++ b/src/signal_service/sealedsender.rs
@@ -2,6 +2,7 @@ use crate::config::SignalConfig;
 use crate::error::Result;
 use crate::store::Storage;
 use crate::store::StorageLocation;
+use libsignal_service::prelude::ProtobufMessage;
 extern crate base64;
 
 use libsignal_service::cipher::ServiceCipher;
@@ -64,15 +65,15 @@ pub async fn decrypt_sealed_message(
     let envelope = Envelope::decrypt(&msg, &signaling_key, false)?;
     let content = cipher.open_envelope(envelope).await?.unwrap();
     println!("sealed message content decrypted");
-    let mut content_vec;
-    match content.body {
-        ContentBody::DataMessage(m) => {
-            content_vec =  content.body.into_proto().encode_to_vec();
-        }
+    let content_vec = match &content.body {
+        ContentBody::DataMessage(m) => content.body.into_proto().encode_to_vec(),
         _ => {
             println!("unexpected content body");
+            // TODO Please check whether the empty vector is intended
+            // Maybe you'd rather want to return an Err?
+            vec![]
         }
-    }
+    };
     let message = base64::encode(&content_vec);
     Ok(DecryptSealedMessageResponse {
         message,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -126,7 +126,7 @@ fn load_file_sync_encrypted(keys: [u8; 16 + 20], path: PathBuf) -> Result<Vec<u8
     let (contents, mac) = contents.split_at_mut(count - 32);
 
     {
-        use hmac::{Hmac};
+        use hmac::{Hmac, Mac, NewMac};
         use sha2::Sha256;
         // Verify HMAC SHA256, 32 last bytes
         let mut verifier = Hmac::<Sha256>::new_from_slice(&keys[16..])
@@ -222,7 +222,7 @@ fn write_file_sync_encrypted(
     };
 
     let mac = {
-        use hmac::{Hmac, Mac};
+        use hmac::{Hmac, Mac, NewMac};
         use sha2::Sha256;
         // Verify HMAC SHA256, 32 last bytes
         let mut mac = Hmac::<Sha256>::new_from_slice(&keys[16..])


### PR DESCRIPTION
This contains some quick fixes (suggestions from rust analyzer) for compiling.

Please note that I made the message an empty vector for unknown `ContentBody` variants in `decrypt_sealed_message()`. Please check whether this is the intended behavior.

The remaining compile issues stem from changed error variants, e.g. `InternalError` does not exist anymore and `SessionNotFound` does not contain a String anymore, but some other data. 