### PR TITLE
Add quotation to crates-io cargo patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ prost-build = "=0.8"
 version_check = "0.9"
 
 [patch.crates-io]
-curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = 'lizard2' }
+"curve25519-dalek" = { git = 'https://github.com/signalapp/curve25519-dalek', branch = 'lizard2' }


### PR DESCRIPTION
The flatpak cargo tooling does not work unless this string is quoted, similarly as is documented in the libsignal-service-rs readme.
See https://github.com/whisperfish/libsignal-service-rs#usage

For full details, see https://github.com/whisperfish/libsignal-service-rs/issues/153