### PR TITLE
Update prost and prost-build dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,8 +375,8 @@ dependencies = [
  "log",
  "pbkdf2",
  "phonenumber",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "rand 0.7.3",
  "regex",
  "rstest",
@@ -541,12 +541,6 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
@@ -1396,21 +1390,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset 0.2.0",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
- "fixedbitset 0.4.2",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -1516,16 +1500,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
-dependencies = [
- "bytes",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
@@ -1545,21 +1519,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.8.0"
+name = "prost"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "heck 0.3.3",
- "itertools 0.10.3",
- "log",
- "multimap",
- "petgraph 0.5.1",
- "prost 0.8.0",
- "prost-types 0.8.0",
- "tempfile",
- "which",
+ "prost-derive 0.11.0",
 ]
 
 [[package]]
@@ -1574,7 +1540,7 @@ dependencies = [
  "lazy_static",
  "log",
  "multimap",
- "petgraph 0.6.2",
+ "petgraph",
  "prost 0.9.0",
  "prost-types 0.9.0",
  "regex",
@@ -1596,7 +1562,7 @@ dependencies = [
  "lazy_static",
  "log",
  "multimap",
- "petgraph 0.6.2",
+ "petgraph",
  "prost 0.10.4",
  "prost-types 0.10.1",
  "regex",
@@ -1605,16 +1571,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.8.0"
+name = "prost-build"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
- "anyhow",
+ "bytes",
+ "heck 0.4.0",
  "itertools 0.10.3",
- "proc-macro2",
- "quote",
- "syn",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.11.0",
+ "prost-types 0.11.1",
+ "regex",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -1644,13 +1617,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.8.0"
+name = "prost-derive"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
- "bytes",
- "prost 0.8.0",
+ "anyhow",
+ "itertools 0.10.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1671,6 +1647,16 @@ checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost 0.10.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "autotools"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +386,7 @@ dependencies = [
  "phonenumber",
  "prost 0.11.0",
  "prost-build 0.11.1",
+ "protobuf-src",
  "rand 0.7.3",
  "regex",
  "rstest",
@@ -1657,6 +1667,15 @@ checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
  "prost 0.11.0",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.0.5+3.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe57f68bf9767f48f8cbcbceb5da21524e2b1330a821c1c2502c447d8043f078"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ dotenv = "0.15"
 regex = "1.3.9"
 rstest = { version = "0.10" }
 prost-build = { version = "0.11.1" }
+protobuf-src = "1.0.5"
 version_check = "0.9"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ failure = "0.1.8"
 futures = "0.3"
 log = "0.4.8"
 phonenumber = "0.3"
-prost = "0.8"
+prost = "0.11.0"
 rand = "0.7"
 serde = "1.0"
 serde_json = "1.0"
@@ -33,6 +33,7 @@ hmac = "0.11.0"
 sha2 = "0.9.0"
 pbkdf2 = { version = "0.8.0", default-features = false }
 sha-1 = "0.9.0"
+
 [build-dependencies]
 cpp_build = "0.5"
 cc = "1.0"
@@ -40,7 +41,7 @@ failure = "0.1.6"
 dotenv = "0.15"
 regex = "1.3.9"
 rstest = { version = "0.10" }
-prost-build = "=0.8"
+prost-build = { version = "0.11.1" }
 version_check = "0.9"
 
 [patch.crates-io]

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,7 @@ fn protobuf() -> Result<(), Error> {
 }
 
 fn main() {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
     protobuf().unwrap();
     let output = Command::new("git")
         .args(&["rev-parse", "HEAD"])


### PR DESCRIPTION
Update `prost` and `prost-build` dependencies.

This as per advice from @LucioFranco in the prost issue:
https://github.com/tokio-rs/prost/issues/712

protoc is added to the project as a separate dependency using the `protobuf-src` crate.

The gitignore file is also amended as to exclude IntelliJ files.

This work is related to https://github.com/nanu-c/crayfish/issues/14

* https://crates.io/crates/prost-build
* https://crates.io/crates/prost