### PR TITLE
Remove one cargo unused import warning

### DIFF
--- a/src/signal_service/sealedsender.rs
+++ b/src/signal_service/sealedsender.rs
@@ -10,7 +10,6 @@ use libsignal_service::configuration::ServiceConfiguration;
 use libsignal_service::configuration::SignalServers;
 use libsignal_service::prelude::Envelope;
 use libsignal_service::ServiceAddress;
-use libsignal_service::content::ContentBody;
 use uuid::Uuid;
 
 // use protocol::envelope::*;


### PR DESCRIPTION
During build, cargo logs some warnings. This PR removes one of them

```log
warning: unused import: `libsignal_service::content::ContentBody`
  --> src/signal_service/sealedsender.rs:13:5
   |
13 | use libsignal_service::content::ContentBody;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```